### PR TITLE
Pass RDF/JS-compatible triples to N3.js

### DIFF
--- a/lib/SerializerStream.js
+++ b/lib/SerializerStream.js
@@ -1,4 +1,3 @@
-const util = require('n3').Util
 const Readable = require('readable-stream')
 const StreamWriter = require('n3').StreamWriter
 
@@ -30,11 +29,7 @@ class SerializerStream extends Readable {
         })
       }
 
-      this.writer.write({
-        subject: SerializerStream.toN3(quad.subject),
-        predicate: SerializerStream.toN3(quad.predicate),
-        object: SerializerStream.toN3(quad.object)
-      })
+      this.writer.write(quad)
     })
 
     input.on('end', () => {
@@ -45,22 +40,6 @@ class SerializerStream extends Readable {
       this.emit('error', err)
     })
   }
-
-  static toN3 (term) {
-    if (term.termType === 'NamedNode') {
-      return term.value
-    } else if (term.termType === 'BlankNode') {
-      return '_:' + term.value
-    } else if (term.termType === 'Literal') {
-      if (term.language) {
-        return util.createLiteral(term.value, term.language)
-      } else if (term.datatype.value === 'http://www.w3.org/2001/XMLSchema#string') {
-        return '"' + term.value + '"'
-      } else {
-        return util.createLiteral(term.value, term.datatype.value)
-      }
-    }
-  }
 }
 
-module.exports = SerializerStream
+module.exports = StreamWriter


### PR DESCRIPTION
Requires latest N3.js develop. Closes #4.